### PR TITLE
:heavy_plus_sign: move types to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@types/express": "^4.17.8",
         "@types/mongodb": "^3.5.31",
         "@types/node": "^14.14.5",
+        "@types/url-join": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^4.6.0",
         "@typescript-eslint/parser": "^4.6.0",
         "eslint": "^7.12.1",
@@ -18,7 +19,6 @@
         "typescript": "^4.0.5"
     },
     "dependencies": {
-        "@types/url-join": "^4.0.0",
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "ejs": "^3.1.6",
@@ -27,7 +27,6 @@
         "mongodb": "^3.6.2",
         "nanoid": "^3.1.20",
         "node-cache": "^5.1.2",
-        "typescript": "^4.0.5",
         "url-join": "^4.0.1",
         "winston": "^3.3.3",
         "yup": "^0.32.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,10 +163,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/url-join@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.0.tgz#72eff71648a429c7d4acf94e03780e06671369bd"
-  integrity sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==
+"@types/url-join@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.1.tgz#4989c97f969464647a8586c7252d97b449cdc045"
+  integrity sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==
 
 "@typescript-eslint/eslint-plugin@^4.6.0":
   version "4.15.0"
@@ -1782,9 +1782,9 @@ type-is@~1.6.17, type-is@~1.6.18:
     mime-types "~2.1.24"
 
 typescript@^4.0.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Move type definition packages to dev dependency! Fixes #20 